### PR TITLE
workaround to fix EACCES in linux

### DIFF
--- a/build/client.js.go
+++ b/build/client.js.go
@@ -13,17 +13,17 @@ exports.createClient = function(args) {
         response.end('');
 		return;
 	  }
-		
+
 	  var body = '';
 	  request.on('data', function(chunk) { body += chunk.toString(); });
 	  request.on('end', function() {
 		switch (request.url) {
-		case '/redirect': 
+		case '/redirect':
 		  channel.emit('redirect', body);
 		  response.writeHead(204);
 		  response.end('');
 		  break;
-		case '/error': 
+		case '/error':
 		  channel.emit('error', body);
 		  response.writeHead(204);
 		  response.end('');
@@ -40,14 +40,18 @@ exports.createClient = function(args) {
         console.log('Listening for golang-nw on '+nodeWebkitAddr);
         startClient(channel, nodeWebkitAddr, args);
     });
-	
+
 	return channel;
 };
-	
+
 function startClient(channel, nodeWebkitAddr, args) {
     var path = require('path');
     var exe = '.'+path.sep+'{{ .Bin }}';
     console.log('Using client: ' + exe);
+
+    // Make the exe executable
+    var fs = require('fs');
+    fs.chmodSync(exe, '755');
 
     // Now start the client process
     var childProcess = require('child_process');
@@ -59,7 +63,7 @@ function startClient(channel, nodeWebkitAddr, args) {
     p.stdout.on('data', function(data) {
         console.log(data.toString());
     });
-	
+
     p.stderr.on('data', function(data) {
         console.error(data.toString());
     });


### PR DESCRIPTION
The problem with EACCES in linux is this:

When you run `myapp.exe` generated by `nw-pkg`, the contents of `myapp.nw` appear in `/tmp/.org.chromium.Chromium.xxxxxx/`

`$ ls /tmp/.org.chromium.Chromium.eEYwZV
client.js  index.html  main  package.json  script.js`

However, `main` is not executable, and that's why it has EACCES.

I don't know what is creating this tmp folder and if it's actually unzipping these files from myapp.nw, otherwise I would modify that to include a `chmod +x main`.  `unzip myapp.nw` unpacks the files with the correct permissions.

In this patch, the correct permissions are set on the exe before spawning it as a child process.
