### PR TITLE
workaround to fix EACCES in linux

### DIFF
--- a/build/client.js.go
+++ b/build/client.js.go
@@ -49,6 +49,10 @@ function startClient(channel, nodeWebkitAddr, args) {
     var exe = '.'+path.sep+'{{ .Bin }}';
     console.log('Using client: ' + exe);
 
+    // Make the exe executable
+    var fs = require('fs');
+    fs.chmodSync(exe, '755');
+
     // Now start the client process
     var childProcess = require('child_process');
 


### PR DESCRIPTION
The problem with EACCES in linux is this:

When you run myapp.exe generated by nw-pkg, the contents of myapp.nw appear in /tmp/.org.chromium.Chromium.xxxxxx/

$ ls /tmp/.org.chromium.Chromium.eEYwZV
client.js index.html main package.json script.js

However, main is not executable, and that's why it has EACCES.

I don't know what is creating this tmp folder and if it's actually unzipping these files from myapp.nw, otherwise I would modify that to include a chmod +x main. unzip myapp.nw unpacks the files with the correct permissions.

In this patch, the correct permissions are set on the exe before spawning it as a child process.

This appears to be an issue with node-webkit:
https://github.com/rogerwang/node-webkit/issues/755
