### PR TITLE
Log newline delimited statements separately

### DIFF
--- a/build/client.js.go
+++ b/build/client.js.go
@@ -48,7 +48,7 @@ function logMessage(data, logger) {
     var lines = data.toString().split('\n');
     for (var i = 0; i < lines.length; i++) {
         if (lines[i]) {
-            logger(lines[i]);
+            logger.call(console, lines[i]);
         }
     }
 }


### PR DESCRIPTION
Newlines in data sent to stdout/stderr are escaped when logged by console.log.  This patch logs each newline-delimited statement in data separately.

e.g. before:
[29718:1227/234957:INFO:CONSOLE(62)] ""App Started\nListening\n"", source: /tmp/.org.chromium.Chromium.7Zg40B/client.js (62)

e.g. after:
[29718:1227/234957:INFO:CONSOLE(62)] ""App Started"", source: /tmp/.org.chromium.Chromium.7Zg40B/client.js (62)
[29718:1227/234957:INFO:CONSOLE(62)] ""Listening"", source: /tmp/.org.chromium.Chromium.7Zg40B/client.js (62)

Empty lines are not logged to avoid the trailing newline.
