### PR TITLE
windows ,the path is like xxx\xxx,to fix this bug.

### DIFF
--- a/build/package.go
+++ b/build/package.go
@@ -111,6 +111,7 @@ func copyIncludes(zw *zip.Writer, includes string) error {
 		if info.IsDir() {
 			return nil
 		}
+		path = strings.Replace(path, "\\", "/", -1)
 		if w, err := zw.Create(strings.TrimPrefix(path, includes)); err != nil {
 			return err
 		} else {


### PR DESCRIPTION
in windows ,the path is like xxx\xxx,to fix this bug.
eg:
path= dlls\some.dll
includes=dlls/
strings.TrimPrefix(path, includes) is the same as  "dlls\some.dll"
