### PR TITLE
Package compatible with recent version of node-webkit (0.11.6).

### DIFF
--- a/cmd/golang-nw-pkg/pkg.go
+++ b/cmd/golang-nw-pkg/pkg.go
@@ -12,12 +12,13 @@ import (
 )
 
 var (
-	app         = "myapp"
-	name        = "My Application"
-	bin         = "myapp"
-	binDir      = "."
-	cacheDir    = "."
-	nwVersion   = "v0.10.5"
+	app      = "myapp"
+	name     = "My Application"
+	bin      = "myapp"
+	binDir   = "."
+	cacheDir = "."
+	//nwVersion   = "v0.10.5"
+	nwVersion   = "v0.11.6"
 	nwOs        = runtime.GOOS
 	nwArch      = runtime.GOARCH
 	toolbar     = true

--- a/pkg/pkg.go
+++ b/pkg/pkg.go
@@ -211,7 +211,7 @@ type pkgOs struct {
 var windows = pkgOs{
 	os:   "win",
 	bin:  "nw.exe",
-	deps: []string{"ffmpegsumo.dll", "icudt.dll", "libEGL.dll", "libGLESv2.dll", "nw.pak"},
+	deps: []string{"ffmpegsumo.dll" /*"icudt.dll"*/, "icudtl.dat", "libEGL.dll", "libGLESv2.dll", "nw.pak"},
 	ext:  ".zip",
 }
 


### PR DESCRIPTION
Package was slightly upgraded to support NW v0.11.6. New node-webkit includes platform-independent `icudtl.dat` instead of `icudt.dll` for Windows.